### PR TITLE
Integration of NetConn() for tls package with some package rename

### DIFF
--- a/pqc/dilithium/dilithium2AES/dilithium2AES.go
+++ b/pqc/dilithium/dilithium2AES/dilithium2AES.go
@@ -1,4 +1,4 @@
-package dilithium2
+package dilithium2aes
 
 import (
 	"crypto"
@@ -49,7 +49,7 @@ func GenerateKey() (*PrivateKey, error) {
 	return privateKey, err
 }
 
-//func (priv *PrivateKey) Sign(random io.Reader, msg []byte, signer crypto.SignerOpts) ([]byte, error)
+// func (priv *PrivateKey) Sign(random io.Reader, msg []byte, signer crypto.SignerOpts) ([]byte, error)
 func (priv *PrivateKey) SignPQC(msg []byte) (sig []byte, err error) {
 	// fmt.Println("----PQC签名开始: ", sigName)
 
@@ -74,7 +74,7 @@ func (priv *PrivateKey) Public() crypto.PublicKey {
 	return &priv.PublicKey
 }
 
-//func (pub *PublicKey) Verify(msg []byte, sig []byte) bool
+// func (pub *PublicKey) Verify(msg []byte, sig []byte) bool
 func (pub *PublicKey) Verify(msg []byte, signature []byte) bool {
 	return Verify(pub, msg, signature)
 }

--- a/pqc/dilithium/dilithium3/dilithium3.go
+++ b/pqc/dilithium/dilithium3/dilithium3.go
@@ -1,4 +1,4 @@
-package dilithium2
+package dilithium3
 
 import (
 	"crypto"
@@ -49,7 +49,7 @@ func GenerateKey() (*PrivateKey, error) {
 	return privateKey, err
 }
 
-//func (priv *PrivateKey) Sign(random io.Reader, msg []byte, signer crypto.SignerOpts) ([]byte, error)
+// func (priv *PrivateKey) Sign(random io.Reader, msg []byte, signer crypto.SignerOpts) ([]byte, error)
 func (priv *PrivateKey) SignPQC(msg []byte) (sig []byte, err error) {
 	// fmt.Println("----PQC签名开始: ", sigName)
 
@@ -74,7 +74,7 @@ func (priv *PrivateKey) Public() crypto.PublicKey {
 	return &priv.PublicKey
 }
 
-//func (pub *PublicKey) Verify(msg []byte, sig []byte) bool
+// func (pub *PublicKey) Verify(msg []byte, sig []byte) bool
 func (pub *PublicKey) Verify(msg []byte, signature []byte) bool {
 	return Verify(pub, msg, signature)
 }

--- a/pqc/dilithium/dilithium3AES/dilithium3AES.go
+++ b/pqc/dilithium/dilithium3AES/dilithium3AES.go
@@ -1,4 +1,4 @@
-package dilithium2
+package dilithium3aes
 
 import (
 	"crypto"
@@ -49,7 +49,7 @@ func GenerateKey() (*PrivateKey, error) {
 	return privateKey, err
 }
 
-//func (priv *PrivateKey) Sign(random io.Reader, msg []byte, signer crypto.SignerOpts) ([]byte, error)
+// func (priv *PrivateKey) Sign(random io.Reader, msg []byte, signer crypto.SignerOpts) ([]byte, error)
 func (priv *PrivateKey) SignPQC(msg []byte) (sig []byte, err error) {
 	// fmt.Println("----PQC签名开始: ", sigName)
 
@@ -74,7 +74,7 @@ func (priv *PrivateKey) Public() crypto.PublicKey {
 	return &priv.PublicKey
 }
 
-//func (pub *PublicKey) Verify(msg []byte, sig []byte) bool
+// func (pub *PublicKey) Verify(msg []byte, sig []byte) bool
 func (pub *PublicKey) Verify(msg []byte, signature []byte) bool {
 	return Verify(pub, msg, signature)
 }

--- a/pqc/dilithium/dilithium5/dilithium5.go
+++ b/pqc/dilithium/dilithium5/dilithium5.go
@@ -1,4 +1,4 @@
-package dilithium2
+package dilithium5
 
 import (
 	"crypto"
@@ -49,7 +49,7 @@ func GenerateKey() (*PrivateKey, error) {
 	return privateKey, err
 }
 
-//func (priv *PrivateKey) Sign(random io.Reader, msg []byte, signer crypto.SignerOpts) ([]byte, error)
+// func (priv *PrivateKey) Sign(random io.Reader, msg []byte, signer crypto.SignerOpts) ([]byte, error)
 func (priv *PrivateKey) SignPQC(msg []byte) (sig []byte, err error) {
 	// fmt.Println("----PQC签名开始: ", sigName)
 
@@ -74,7 +74,7 @@ func (priv *PrivateKey) Public() crypto.PublicKey {
 	return &priv.PublicKey
 }
 
-//func (pub *PublicKey) Verify(msg []byte, sig []byte) bool
+// func (pub *PublicKey) Verify(msg []byte, sig []byte) bool
 func (pub *PublicKey) Verify(msg []byte, signature []byte) bool {
 	return Verify(pub, msg, signature)
 }

--- a/pqc/dilithium/dilithium5AES/dilithium5AES.go
+++ b/pqc/dilithium/dilithium5AES/dilithium5AES.go
@@ -1,4 +1,4 @@
-package dilithium2
+package dilithium5aes
 
 import (
 	"crypto"
@@ -49,7 +49,7 @@ func GenerateKey() (*PrivateKey, error) {
 	return privateKey, err
 }
 
-//func (priv *PrivateKey) Sign(random io.Reader, msg []byte, signer crypto.SignerOpts) ([]byte, error)
+// func (priv *PrivateKey) Sign(random io.Reader, msg []byte, signer crypto.SignerOpts) ([]byte, error)
 func (priv *PrivateKey) SignPQC(msg []byte) (sig []byte, err error) {
 	// fmt.Println("----PQC签名开始: ", sigName)
 
@@ -74,7 +74,7 @@ func (priv *PrivateKey) Public() crypto.PublicKey {
 	return &priv.PublicKey
 }
 
-//func (pub *PublicKey) Verify(msg []byte, sig []byte) bool
+// func (pub *PublicKey) Verify(msg []byte, sig []byte) bool
 func (pub *PublicKey) Verify(msg []byte, signature []byte) bool {
 	return Verify(pub, msg, signature)
 }

--- a/pqc/falcon/falcon1024/falcon1024.go
+++ b/pqc/falcon/falcon1024/falcon1024.go
@@ -1,4 +1,4 @@
-package falcon512
+package falcon1024
 
 import (
 	"crypto"
@@ -49,7 +49,7 @@ func GenerateKey() (*PrivateKey, error) {
 	return privateKey, err
 }
 
-//func (priv *PrivateKey) Sign(random io.Reader, msg []byte, signer crypto.SignerOpts) ([]byte, error)
+// func (priv *PrivateKey) Sign(random io.Reader, msg []byte, signer crypto.SignerOpts) ([]byte, error)
 func (priv *PrivateKey) SignPQC(msg []byte) (sig []byte, err error) {
 	// fmt.Println("----PQC签名开始: ", sigName)
 
@@ -74,7 +74,7 @@ func (priv *PrivateKey) Public() crypto.PublicKey {
 	return &priv.PublicKey
 }
 
-//func (pub *PublicKey) Verify(msg []byte, sig []byte) bool
+// func (pub *PublicKey) Verify(msg []byte, sig []byte) bool
 func (pub *PublicKey) Verify(msg []byte, signature []byte) bool {
 	return Verify(pub, msg, signature)
 }

--- a/tls/conn.go
+++ b/tls/conn.go
@@ -151,6 +151,13 @@ func (c *Conn) SetWriteDeadline(t time.Time) error {
 	return c.conn.SetWriteDeadline(t)
 }
 
+// NetConn returns the underlying connection that is wrapped by c.
+// Note that writing to or reading from this connection directly will corrupt the
+// TLS session.
+func (c *Conn) NetConn() net.Conn {
+	return c.conn
+}
+
 // A halfConn represents one direction of the record layer
 // connection, either sending or receiving.
 type halfConn struct {
@@ -580,12 +587,14 @@ func (c *Conn) readChangeCipherSpec() error {
 
 // readRecordOrCCS reads one or more TLS records from the connection and
 // updates the record layer state. Some invariants:
-//   * c.in must be locked
-//   * c.input must be empty
+//   - c.in must be locked
+//   - c.input must be empty
+//
 // During the handshake one and only one of the following will happen:
 //   - c.hand grows
 //   - c.in.changeCipherSpec is called
 //   - an error is returned
+//
 // After the handshake one and only one of the following will happen:
 //   - c.hand grows
 //   - c.input is set


### PR DESCRIPTION
To make the library interfaceable with the framework I am modifying, I added the NetConn() function found in the crypto/tls library (go version go1.19.3 linux/amd64).  I also changed the name of some packages following golang's best practice